### PR TITLE
Add 'provide' statement for loading this package

### DIFF
--- a/pyenv-mode-auto.el
+++ b/pyenv-mode-auto.el
@@ -45,6 +45,8 @@
 
 (add-hook 'find-file-hook 'pyenv-mode-auto-hook)
 
+(provide 'pyenv-mode-auto)
+
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; End:


### PR DESCRIPTION
Without `provide`, we cannot load this package by `require`.

```
(require 'pyenv-mode-auto)
;; Error: "Required feature `pyenv-mode-auto' was not provided"
```
